### PR TITLE
Add importation of case models and casemodel name as filename for download

### DIFF
--- a/public_src/js/api.js
+++ b/public_src/js/api.js
@@ -123,6 +123,16 @@ API.prototype.createScenario = function(name, callback) {
     });
 };
 
+API.prototype.importCaseModel = function(casemodel, callback) {
+    $.ajax({
+        url: this.createURL("scenario"),
+        type: "POST",
+        contentType: "application/json",
+        data: JSON.stringify(casemodel),
+        complete: callback
+    });
+};
+
 API.prototype.deleteFragment = function(id, callback) {
     $.ajax({
         url: this.createURL("fragment/" + id),

--- a/public_src/js/react/indexpage.js
+++ b/public_src/js/react/indexpage.js
@@ -145,6 +145,15 @@ var IndexComponent = React.createClass({
                           <i className="fa fa-plus"></i> create new case model
                       </a>
                     </div>
+                    <div className="col-md-2">
+                      <a
+                          href="#"
+                          data-toggle="modal"
+                          data-target="#importCaseModelModal"
+                      >
+                          <i className="fa fa-plus"></i> import case model
+                      </a>
+                    </div>
                   </div>
                 </div>
 

--- a/public_src/js/react/modals/importcasemodelmodal.js
+++ b/public_src/js/react/modals/importcasemodelmodal.js
@@ -1,0 +1,124 @@
+var React = require('react');
+var API = require('./../../api');
+var NameCheck = require('./../../namecheck');
+var SideBarManager = require('./../../sidebarmanager');
+var Redirecter = require('./../../redirecter');
+var MessageHandler = require('./../../messagehandler');
+
+var ImportCaseModelModal = React.createClass({
+    getInitialState: function() {
+        return {
+            file: '',
+            content: ''
+        }
+    },
+    handleSubmit: function(e) {
+        if (NameCheck.check(this.state.content.name)) {
+            API.importCaseModel(this.state.content, function(data){
+                if ("err_code" in data) {
+                    MessageHandler.handleMessage(data.type, data.text);
+                } else {
+                    SideBarManager.reload();
+                    Redirecter.redirectToScenario(data.responseJSON._id);
+                }
+            });
+            $('#importCaseModelModal').modal('hide');
+        }
+    },
+    handleFileChange: function(e) {
+        var file = e.target.files[0];
+        this.setState({file: file}, this.readFileContent);
+    },
+    readFileContent: function() {
+        var reader = new FileReader();
+        reader.onprogress = this.loadProgress;
+        reader.onloadend = this.loaded;
+        reader.onerror = this.loadError;
+        reader.readAsText(this.state.file);
+    },
+    loaded: function(e) {
+        document.body.style.cursor='default';
+        var fileContent = e.target.result;
+        try {
+            var content = JSON.parse(fileContent);
+            this.setState({content: content});
+        } catch(e) {
+            this.setState({content: ''});
+            MessageHandler.handleMessage('danger', 'The file does not contain a valid Json object.');
+        }
+    },
+    loadProgress: function(e) {
+        document.body.style.cursor='wait';
+    },
+    loadError: function(e) {
+        document.body.style.cursor='default';
+        MessageHandler.handleMessage('danger', 'A problem occured during the upload.');
+    },
+    handleNameChange: function(e) {
+        var content = this.state.content;
+        content.name = e.target.value;
+        this.setState({content: content});
+    },
+    handleNameEnterSubmit: function(e) {
+        if (e.keyCode == 13) {
+            this.handleSubmit();
+        }
+    },
+    render: function() {
+        const changeCaseModelName = this.state.content ?
+            <div>
+                <br />
+                <label htmlFor="importCaseModelModalName">Case Model Name</label>
+                <input
+                    type="text"
+                    className="form-control"
+                    id="importCaseModelModalName"
+                    placeholder="Enter case model name"
+                    value={this.state.content.name}
+                    onChange={this.handleNameChange}
+                    onKeyDown={this.handleNameEnterSubmit}
+                />
+            </div>
+            : '';
+        return (
+            <div className="modal fade bs-example-modal-sm" tabIndex="-1" role="dialog" aria-labelledby="importCaseModelModalTitle" id="importCaseModelModal">
+                <div className="modal-dialog">
+                    <div className="modal-content">
+                        <form>
+                            <div className="modal-header">
+                                <button type="button" className="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                                <h4 className="modal-title" id="importCaseModelModalTitle">Import a case model</h4>
+                            </div>
+                            <div className="modal-body">
+                                <fieldset className="form-group">
+                                    <input
+                                        type="file"
+                                        accept=".json"
+                                        className="form-control"
+                                        id="importCaseModelModalFile"
+                                        onChange={this.handleFileChange}
+                                    />
+                                    {changeCaseModelName}
+                                </fieldset>
+                            </div>
+                            <div className="modal-footer">
+                                <button type="button" className="btn" data-dismiss="modal">Close</button>
+                                <button
+                                    type="button"
+                                    className="btn btn-default btn-primary"
+                                    onClick={this.handleSubmit}
+                                    disabled={!this.state.content}
+                                >
+                                    Import
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        )
+    }
+});
+module.exports = ImportCaseModelModal;

--- a/public_src/js/react/modals/modals.js
+++ b/public_src/js/react/modals/modals.js
@@ -10,6 +10,7 @@ var DeleteScenarioModal = require('./deletescenario');
 var DeleteFragmentModal = require('./deletefragment');
 var ExportScenarioModal = require('./exportscenario');
 var ModifyExportTargetsModal = require('./modifyexporttargets');
+var ImportCaseModelModal = require('./importcasemodelmodal');
 
 /**
  * All modals used in the project
@@ -37,6 +38,7 @@ var ModalComponent = React.createClass({
                 <DeleteScenarioModal />
                 <ExportScenarioModal />
                 <ModifyExportTargetsModal />
+                <ImportCaseModelModal />
             </div>
         )
     }

--- a/server_src/routes/fragment.js
+++ b/server_src/routes/fragment.js
@@ -62,7 +62,7 @@ router.post('/:fragID', function(req, res) {
                 changed = true;
                 result.content = new_frag.content;
             }
-            
+
             if (new_frag.preconditions != null && ! (_.isEqual(result.preconditions, new_frag.preconditions))) {
                 changed = true;
                 result.preconditions = new_frag.preconditions;
@@ -72,12 +72,12 @@ router.post('/:fragID', function(req, res) {
 				changed = true;
 				result.policy = new_frag.policy;
 			}
-			
+
 			if (new_frag.bound != null && ! (_.isEqual(result.bound, new_frag.bound))) {
 				changed = true;
 				result.bound = new_frag.bound;
 			}
-			
+
             if (changed) {
                 result.revision++;
                 result.save(function(err){
@@ -126,8 +126,8 @@ router.post('/', function(req, res) {
         name: fragment.name,
         content: (fragment.content ? fragment.content : Config.DEFAULT_FRAGMENT_XML),
         preconditions: (fragment.preconditions ? fragment.preconditions : [""]),
-		policy: (fragment.policy ? fragment.policy : Config.DEFAULT_FRAGMENT_POLICY),
-		bound: (fragment.bound ? fragment.bound : {hasBound: false, limit: Config.DEFAULT_FRAGMENT_INSTANTIATION_AMOUNT}),
+        policy: (fragment.policy ? fragment.policy : Config.DEFAULT_FRAGMENT_POLICY),
+        bound: (fragment.bound ? fragment.bound : {hasBound: false, limit: Config.DEFAULT_FRAGMENT_INSTANTIATION_AMOUNT}),
         revision: 1
     });
 


### PR DESCRIPTION
Create case models from existing json files. This **does not work** for case models that were downloaded **before** this feature existed.

In addition the download name of case models is now the name instead of the id.

## Description
Next to `create new case model` on the homepage is now a button `import case model` that opens a modal.
This modal provides a file upload for `json` files. If a json file with a correct json object was uploaded, the user can adapt the name of the case model that will be created. `Import` than creates a new case model with the data from the file.
For now only case models that were created since this feature exists will result in a correct deployed case model because the xml for the olc was not saved in previous versions.
In the future the import behavior could be adpated to update old downloaded case models.

## Related Issue
#29 

## How Has This Been Tested?
This feature was tested will several downloaded json files from different case models.