### PR TITLE
Fix deletion of case start trigger line

### DIFF
--- a/public_src/js/react/scenarioeditor/startconditions.js
+++ b/public_src/js/react/scenarioeditor/startconditions.js
@@ -212,7 +212,11 @@ var CaseStartTriggerComponent = React.createClass({
     handleDelete: function(index, tindex) {
         return function(e) {
             var condition = this.props.condition;
-            condition['dataclasses'][index]['mapping'].splice(tindex,1);
+            if (condition['dataclasses'][index]['mapping'].length == 1) {
+                condition['dataclasses'].splice(index, 1);
+            } else {
+                condition['dataclasses'][index]['mapping'].splice(tindex,1);
+            }
             this.props.handleUpdate(condition);
             this.props.handleSubmit();
         }.bind(this)


### PR DESCRIPTION
The last mapping of one dataclass in a case start trigger can now be deleted.

## Description
If the last mapping of one dataclass in a case start trigger will be deleted. The dataclass will be removed from the internal object and not just the mapping for the dataclass.

## Related Issue
Fixes #38