### PR TITLE
Strip newlines from OLC state names

### DIFF
--- a/public_src/js/react/domainmodeleditor/domainmodeleditor.js
+++ b/public_src/js/react/domainmodeleditor/domainmodeleditor.js
@@ -136,6 +136,17 @@ var DomainModelEditorComponent = React.createClass({
             return true; //signal successful creation (evaluated by invoking component)
         }
     },
+    stripLineFeeds: function(newDm) {
+      for (let i = 0; i < newDm.dataclasses.length; i++) {
+        let dataclass = newDm.dataclasses[i];
+        let newOlc = dataclass.olc.replace(/name="([^"]+)&#10;"/g, function(string, matchedGroup){
+          console.log("Stripping newline from state name: ", string, " matchedGroup: ", matchedGroup);
+          return "name=\"" + matchedGroup + "\"";
+        });
+        dataclass.olc = newOlc;
+      }
+      return newDm;
+    },
     handleOlcChanged: function(olcDm) {
         var targetClassId = this.props.params.dataclassId;
         var mergedDomainModelClasses = this.state.dm.dataclasses.map(function(dataclass) {
@@ -152,6 +163,9 @@ var DomainModelEditorComponent = React.createClass({
         });
         var newDm = this.state.dm;
         newDm.dataclasses = mergedDomainModelClasses;
+
+        // While we're at it, strip these weird line feeds
+        newDM = this.stripLineFeeds(newDm);
 
         this.setState({'dm':newDm, 'changed':true}, function () {
           this.handleExport();

--- a/server_src/helpers/olcvalidator.js
+++ b/server_src/helpers/olcvalidator.js
@@ -81,7 +81,7 @@ var OLCValidator = class {
         }.bind(this);
     }
 
-    
+
     /**
      * Returns the dataobjectreference with the given ID
      * @method getDataObjectReference
@@ -122,15 +122,17 @@ var OLCValidator = class {
      * @param doref
      */
     validateDataObjectReference(doref) {
-        if (!(doref['griffin:dataclass'] in this.olc)) {
+        var referencedDataClass = doref['griffin:dataclass'].trim();
+        var referencedState = doref['griffin:state'].trim();
+        if (!(referencedDataClass in this.olc)) {
             this.messages.push({
                 'text': 'You referenced an invalid dataclass. (' + doref['griffin:dataclass'] + ')',
                 'type': 'danger'
             })
         } else {
-            if (this.olc[doref['griffin:dataclass']] != null && !(doref['griffin:state'] in this.olc[doref['griffin:dataclass']])) {
+            if (this.olc[referencedDataClass] != null && !(referencedState in this.olc[referencedDataClass])) {
                 this.messages.push({
-                    'text': 'You referenced an invalid state (' + doref['griffin:state'] + ') for data object ' + doref['griffin:dataclass'],
+                    'text': 'You referenced an invalid state (' + referencedState + ') for data object ' + referencedDataClass + '. Available states: \'' + Object.keys(this.olc[referencedDataClass]).join("\', \'") + '\'',
                     'type': 'danger'
                 })
             }
@@ -201,7 +203,7 @@ var OLCValidator = class {
                         this.messages.push({
                             'text': iotuple.instate + ' -> ' + iotuple.outstate + ' is not a valid state change (no direct connection) according to the olc of the dataclass ' + iotuple.dataclass,
                             'type': 'danger'
-                        })                  
+                        })
                     }
                 }
             }


### PR DESCRIPTION
This strips newlines in OLC state names from the generated BPMN XML when saving.

It would be nicer if this wouldn't happen in the first place. So this is *not* a fix for the root cause!

Closes #44.