### PR TITLE
Resource/add resource cb to datamodel

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -32,6 +32,15 @@ var CONFIGURATION = {
      * The Mongo-DB Path that should be used (it should specify host and collection)
      */
     MONGODB_HOST: 'mongodb://localhost/gryphondb'
+
+    /**
+     * ### Resource Manager Configuration
+     */
+
+    /**
+     * The host address of the resource manager
+     */
+    RESOURCE_MANAGER_HOST: 'http://localhost:3500/',
 };
 
 module.exports = CONFIGURATION

--- a/docs/backenddocumentation/files/models_domainmodel.js.html
+++ b/docs/backenddocumentation/files/models_domainmodel.js.html
@@ -149,6 +149,7 @@ var DomainModelSchema = new Schema({
         name: String,
         is_root: Boolean,
         is_event: Boolean,
+        is_resource: Boolean,
         attributes: [{
             name: String,
             datatype: String

--- a/docs/backenddocumentation/files/models_domainmodel.js.html
+++ b/docs/backenddocumentation/files/models_domainmodel.js.html
@@ -150,6 +150,7 @@ var DomainModelSchema = new Schema({
         is_root: Boolean,
         is_event: Boolean,
         is_resource: Boolean,
+        resource_id: String,
         attributes: [{
             name: String,
             datatype: String

--- a/public/swagger/swagger.yaml
+++ b/public/swagger/swagger.yaml
@@ -932,6 +932,9 @@ definitions:
       is_event:
         type: boolean
         description: 'Describes whether the data class represents event data.'
+      is_resource:
+        type: boolean
+        description: 'Describes whether the data class represents a resource in the resource manager.'
       attributes:
         type: array
         description: 'The attributes of the data class.'

--- a/public/swagger/swagger.yaml
+++ b/public/swagger/swagger.yaml
@@ -935,6 +935,9 @@ definitions:
       is_resource:
         type: boolean
         description: 'Describes whether the data class represents a resource in the resource manager.'
+      resource_id:
+        type: string
+        description: 'The ID of the selected resource type (in case the data object refers to a resource).'
       attributes:
         type: array
         description: 'The attributes of the data class.'

--- a/public_src/js/react/domainmodeleditor/CreateNewClass.js
+++ b/public_src/js/react/domainmodeleditor/CreateNewClass.js
@@ -12,11 +12,12 @@ var CreateNewClassComponent = React.createClass({
     handleSubmit: function(type) {
         var is_event = false;
         var is_resource = false;
+        var resource_id = null;
         if (type == "event") {is_event = true;}
         if (type == "resource") {is_resource = true;}
         var newItem = this.state.newname;
         if (NameCheck.check(newItem)) {
-            if (this.props.onSubmit(newItem, is_event, is_resource)) {
+            if (this.props.onSubmit(newItem, is_event, is_resource, resource_id)) {
                 this.setState({newname: ''});
             }
         }

--- a/public_src/js/react/domainmodeleditor/CreateNewClass.js
+++ b/public_src/js/react/domainmodeleditor/CreateNewClass.js
@@ -11,10 +11,12 @@ var CreateNewClassComponent = React.createClass({
     },
     handleSubmit: function(type) {
         var is_event = false;
+        var is_resource = false;
         if (type == "event") {is_event = true;}
+        if (type == "resource") {is_resource = true;}
         var newItem = this.state.newname;
         if (NameCheck.check(newItem)) {
-            if (this.props.onSubmit(newItem, is_event)) {
+            if (this.props.onSubmit(newItem, is_event, is_resource)) {
                 this.setState({newname: ''});
             }
         }

--- a/public_src/js/react/domainmodeleditor/DataClass.js
+++ b/public_src/js/react/domainmodeleditor/DataClass.js
@@ -20,6 +20,7 @@ var DataClassComponent = React.createClass({
             this.props.handleUpdate({
                 name: this.props.name,
                 is_event: this.props.is_event,
+                is_resource: this.props.is_resource,
                 attributes: newItems,
                 _id: this.props.id
             });
@@ -37,15 +38,18 @@ var DataClassComponent = React.createClass({
         this.props.handleUpdate({
             name: this.props.name,
             is_event: this.props.is_event,
+            is_resource: this.props.is_resource,
             attributes: this.state.items,
             _id: this.props.id
         });
     },
-    handleType: function(new_is_event) {
+    handleType: function(new_is_event, new_is_resource) {
         var is_event = new_is_event;
+        var is_resource = new_is_resource;
         this.props.handleUpdate({
             name: this.props.name,
             is_event: is_event,
+            is_resource: is_resource,
             attributes: this.state.items,
             _id: this.props.id
         });
@@ -54,6 +58,7 @@ var DataClassComponent = React.createClass({
         this.props.handleUpdate({
             name: e.target.value,
             is_event: this.props.is_event,
+            is_resource: this.props.is_resource,
             attributes: this.state.items,
             _id: this.props.id
         });
@@ -86,6 +91,7 @@ var DataClassComponent = React.createClass({
             this.props.handleUpdate({
                 name: this.props.name,
                 is_event: this.props.is_event,
+                is_resource: this.props.is_resource,
                 attributes: this.state.items,
                 _id: this.props.id
             });
@@ -124,6 +130,7 @@ var DataClassComponent = React.createClass({
                     handleDelete={this.props.handleDelete}
                     exportClass={this.exportClass}
                     is_event={this.props.is_event}
+                    is_resource={this.props.is_resource}
                     scenid={this.props.scenid}
                     changed={this.props.modelChanged}
                 />

--- a/public_src/js/react/domainmodeleditor/DataClass.js
+++ b/public_src/js/react/domainmodeleditor/DataClass.js
@@ -21,6 +21,7 @@ var DataClassComponent = React.createClass({
                 name: this.props.name,
                 is_event: this.props.is_event,
                 is_resource: this.props.is_resource,
+                resource_id: this.props.resource_id,
                 attributes: newItems,
                 _id: this.props.id
             });
@@ -39,17 +40,20 @@ var DataClassComponent = React.createClass({
             name: this.props.name,
             is_event: this.props.is_event,
             is_resource: this.props.is_resource,
+            resource_id: this.props.resource_id,
             attributes: this.state.items,
             _id: this.props.id
         });
     },
-    handleType: function(new_is_event, new_is_resource) {
+    handleType: function(new_is_event, new_is_resource, new_resource_id) {
         var is_event = new_is_event;
         var is_resource = new_is_resource;
+        var resource_id = new_resource_id;
         this.props.handleUpdate({
             name: this.props.name,
             is_event: is_event,
             is_resource: is_resource,
+            resource_id: resource_id,
             attributes: this.state.items,
             _id: this.props.id
         });
@@ -59,6 +63,7 @@ var DataClassComponent = React.createClass({
             name: e.target.value,
             is_event: this.props.is_event,
             is_resource: this.props.is_resource,
+            resource_id: this.props.resource_id,
             attributes: this.state.items,
             _id: this.props.id
         });
@@ -92,6 +97,7 @@ var DataClassComponent = React.createClass({
                 name: this.props.name,
                 is_event: this.props.is_event,
                 is_resource: this.props.is_resource,
+                resource_id: this.props.resource_id,
                 attributes: this.state.items,
                 _id: this.props.id
             });
@@ -131,6 +137,7 @@ var DataClassComponent = React.createClass({
                     exportClass={this.exportClass}
                     is_event={this.props.is_event}
                     is_resource={this.props.is_resource}
+                    resource_id={this.props.resource_id}
                     scenid={this.props.scenid}
                     changed={this.props.modelChanged}
                 />

--- a/public_src/js/react/domainmodeleditor/DataClassHeader.js
+++ b/public_src/js/react/domainmodeleditor/DataClassHeader.js
@@ -9,6 +9,7 @@ var DataClassHeaderComponent = React.createClass({
                     <div className="col-sm-8 col-md-6 col-lg-4">
                         <TypeSelect
                             is_event={this.props.is_event}
+                            is_resource={this.props.is_resource}
                             handleType={this.props.handleType}
                         />
                     </div>

--- a/public_src/js/react/domainmodeleditor/DataClassHeader.js
+++ b/public_src/js/react/domainmodeleditor/DataClassHeader.js
@@ -10,6 +10,7 @@ var DataClassHeaderComponent = React.createClass({
                         <TypeSelect
                             is_event={this.props.is_event}
                             is_resource={this.props.is_resource}
+                            resource_id={this.props.resource_id}
                             handleType={this.props.handleType}
                         />
                     </div>

--- a/public_src/js/react/domainmodeleditor/DomainModelEditor.js
+++ b/public_src/js/react/domainmodeleditor/DomainModelEditor.js
@@ -47,11 +47,12 @@ var DomainModelEditorComponent = React.createClass({
             this.setState({'dm':dm, 'changed':true});
         }.bind(this);
     },
-    handleCreateNew: function(name, is_event, is_resource) {
+    handleCreateNew: function(name, is_event, is_resource, resource_id) {
         var dataclass = {
             "name": name,
             "is_event": is_event,
             "is_resource": is_resource,
+            "resource_id": resource_id,
             "attributes": [],
             "olc": Config.DEFAULT_OLC_XML
         };
@@ -121,6 +122,7 @@ var DomainModelEditorComponent = React.createClass({
               name={selectedDataclass.name}
               is_event={selectedDataclass.is_event}
               is_resource={selectedDataclass.is_resource}
+              resource_id={selectedDataclass.resource_id}
               availableDataTypes={this.getAvailableDataTypes()}
               modelChanged={this.state.changed}
               id={selectedDataclass._id}

--- a/public_src/js/react/domainmodeleditor/DomainModelEditor.js
+++ b/public_src/js/react/domainmodeleditor/DomainModelEditor.js
@@ -47,10 +47,11 @@ var DomainModelEditorComponent = React.createClass({
             this.setState({'dm':dm, 'changed':true});
         }.bind(this);
     },
-    handleCreateNew: function(name, is_event) {
+    handleCreateNew: function(name, is_event, is_resource) {
         var dataclass = {
             "name": name,
             "is_event": is_event,
+            "is_resource": is_resource,
             "attributes": [],
             "olc": Config.DEFAULT_OLC_XML
         };
@@ -119,6 +120,7 @@ var DomainModelEditorComponent = React.createClass({
               initialItems={selectedDataclass.attributes}
               name={selectedDataclass.name}
               is_event={selectedDataclass.is_event}
+              is_resource={selectedDataclass.is_resource}
               availableDataTypes={this.getAvailableDataTypes()}
               modelChanged={this.state.changed}
               id={selectedDataclass._id}

--- a/public_src/js/react/domainmodeleditor/TypeSelect.js
+++ b/public_src/js/react/domainmodeleditor/TypeSelect.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var ResourceAPI = require('./../../resourceApi');
 
 var TypeSelect = React.createClass({
     getInitialState: function () {
@@ -6,6 +7,13 @@ var TypeSelect = React.createClass({
             isEvent: this.props.is_event,
             isResource: this.props.is_resource
         };
+    },
+    componentDidMount: function () {
+        ResourceAPI.getAvailableResourceTypes(function (data) {
+            if (this.isMounted()) {
+                this.setState({ 'availableResourceTypes': data["resources"] });
+            }
+        }.bind(this));
     },
     handleChange: function (event) {
         if (event.target.value === "isEvent") {
@@ -18,7 +26,8 @@ var TypeSelect = React.createClass({
             this.setState({ isResource: isResource });
             this.props.handleType(this.state.isEvent, isResource);
         }
-        
+        console.log(this.state);
+
     },
     componentWillReceiveProps: function (nextProps) {
         this.setState({
@@ -29,26 +38,38 @@ var TypeSelect = React.createClass({
     render: function () {
         var value = this.state.value;
         return (
-            <div className="checkbox">
-                <label>
-                    <input
-                        type="checkbox"
-                        value="isEvent"
-                        checked={this.state.isEvent}
-                        onChange={this.handleChange}
-                    />
-                    Use as event type
-                </label>
-                <label>
-                    <input
-                        type="checkbox"
-                        value="isResource"
-                        checked={this.state.isResource}
-                        onChange={this.handleChange}
-                    />
-                    Use as a resource
-                </label>
+            <div>
+                <div className="checkbox">
+                    <label>
+                        <input
+                            type="checkbox"
+                            value="isEvent"
+                            checked={this.state.isEvent}
+                            onChange={this.handleChange}
+                        />
+                        Use as event type
+                    </label>
+                    <label>
+                        <input
+                            type="checkbox"
+                            value="isResource"
+                            checked={this.state.isResource}
+                            onChange={this.handleChange}
+                        />
+                        Use as a resource
+                    </label>
+                </div>
+                {this.state.isResource && this.state.availableResourceTypes && 
+                    <div>
+                        <select>
+                        {this.state.availableResourceTypes.map(type => {
+                            return(<option key={type["id"]} value={type["id"]}>{type["name"]}</option>);
+                        })}
+                        </select>
+                    </div>
+                }
             </div>
+
         );
     }
 });

--- a/public_src/js/react/domainmodeleditor/TypeSelect.js
+++ b/public_src/js/react/domainmodeleditor/TypeSelect.js
@@ -18,7 +18,6 @@ var TypeSelect = React.createClass({
             this.setState({ isResource: isResource });
             this.props.handleType(this.state.isEvent, isResource);
         }
-        console.log(this.state);
         
     },
     componentWillReceiveProps: function (nextProps) {

--- a/public_src/js/react/domainmodeleditor/TypeSelect.js
+++ b/public_src/js/react/domainmodeleditor/TypeSelect.js
@@ -1,28 +1,53 @@
 var React = require('react');
 
 var TypeSelect = React.createClass({
-    getInitialState: function() {
-        return {isEvent: this.props.is_event};
+    getInitialState: function () {
+        return {
+            isEvent: this.props.is_event,
+            isResource: this.props.is_resource
+        };
     },
-    handleChange: function(event) {
-        var isEvent = event.target.checked == true;
-        this.setState({isEvent: isEvent});
-        this.props.handleType(isEvent);
+    handleChange: function (event) {
+        if (event.target.value === "isEvent") {
+            var isEvent = event.target.checked == true;
+            this.setState({ isEvent: isEvent });
+            this.props.handleType(isEvent, this.state.isResource);
+        }
+        else {
+            var isResource = event.target.checked == true;
+            this.setState({ isResource: isResource });
+            this.props.handleType(this.state.isEvent, isResource);
+        }
+        console.log(this.state);
+        
     },
-    componentWillReceiveProps: function(nextProps) {
-        this.setState({isEvent: nextProps.is_event});
+    componentWillReceiveProps: function (nextProps) {
+        this.setState({
+            isEvent: nextProps.is_event,
+            isResource: nextProps.is_resource
+        });
     },
-    render: function() {
+    render: function () {
         var value = this.state.value;
         return (
             <div className="checkbox">
                 <label>
-                <input
-                    type="checkbox"
-                    checked={this.state.isEvent}
-                    onChange={this.handleChange}
-                />
-                Use as event type
+                    <input
+                        type="checkbox"
+                        value="isEvent"
+                        checked={this.state.isEvent}
+                        onChange={this.handleChange}
+                    />
+                    Use as event type
+                </label>
+                <label>
+                    <input
+                        type="checkbox"
+                        value="isResource"
+                        checked={this.state.isResource}
+                        onChange={this.handleChange}
+                    />
+                    Use as a resource
                 </label>
             </div>
         );

--- a/public_src/js/react/domainmodeleditor/TypeSelect.js
+++ b/public_src/js/react/domainmodeleditor/TypeSelect.js
@@ -5,7 +5,8 @@ var TypeSelect = React.createClass({
     getInitialState: function () {
         return {
             isEvent: this.props.is_event,
-            isResource: this.props.is_resource
+            isResource: this.props.is_resource,
+            resourceId: this.props.resource_id,
         };
     },
     componentDidMount: function () {
@@ -16,23 +17,32 @@ var TypeSelect = React.createClass({
         }.bind(this));
     },
     handleChange: function (event) {
-        if (event.target.value === "isEvent") {
-            var isEvent = event.target.checked == true;
-            this.setState({ isEvent: isEvent });
-            this.props.handleType(isEvent, this.state.isResource);
+        switch(event.target.name) {
+            case "isEvent":
+                this.setState({ isEvent: event.target.checked });
+                this.props.handleType(event.target.checked, this.state.isResource, this.state.resourceId);
+                break;
+            case "isResource":
+                this.setState({ isResource: event.target.checked });
+                let currentResourceId = this.state.resourceId;
+                if (currentResourceId == null) {
+                    currentResourceId = String(this.state.availableResourceTypes[0]["id"]);
+                    this.setState({ 'resourceId': currentResourceId });
+                }
+                this.props.handleType(this.state.isEvent, event.target.checked, currentResourceId);
+                break;
+            case "resourceId":
+                this.setState({ resourceId: event.target.value });
+                this.props.handleType(this.state.isEvent, this.state.isResource, event.target.value);
+                break;
         }
-        else {
-            var isResource = event.target.checked == true;
-            this.setState({ isResource: isResource });
-            this.props.handleType(this.state.isEvent, isResource);
-        }
-        console.log(this.state);
 
     },
     componentWillReceiveProps: function (nextProps) {
         this.setState({
             isEvent: nextProps.is_event,
-            isResource: nextProps.is_resource
+            isResource: nextProps.is_resource,
+            resourceId: nextProps.resource_id,
         });
     },
     render: function () {
@@ -43,7 +53,7 @@ var TypeSelect = React.createClass({
                     <label>
                         <input
                             type="checkbox"
-                            value="isEvent"
+                            name="isEvent"
                             checked={this.state.isEvent}
                             onChange={this.handleChange}
                         />
@@ -52,7 +62,7 @@ var TypeSelect = React.createClass({
                     <label>
                         <input
                             type="checkbox"
-                            value="isResource"
+                            name="isResource"
                             checked={this.state.isResource}
                             onChange={this.handleChange}
                         />
@@ -61,7 +71,7 @@ var TypeSelect = React.createClass({
                 </div>
                 {this.state.isResource && this.state.availableResourceTypes && 
                     <div>
-                        <select>
+                        <select name="resourceId" value={this.state.resourceId} onChange={this.handleChange}>
                         {this.state.availableResourceTypes.map(type => {
                             return(<option key={type["id"]} value={type["id"]}>{type["name"]}</option>);
                         })}

--- a/public_src/js/react/modals/createdomainmodelclass.js
+++ b/public_src/js/react/modals/createdomainmodelclass.js
@@ -30,6 +30,7 @@ var CreateDomainModelClassModal = React.createClass({
           "name": this.state.name,
           "is_event": false,
           "is_resource": false,
+          "resource_id": null,
           "attributes": [],
           "olc": Config.DEFAULT_OLC_XML
       };

--- a/public_src/js/react/modals/createdomainmodelclass.js
+++ b/public_src/js/react/modals/createdomainmodelclass.js
@@ -29,6 +29,7 @@ var CreateDomainModelClassModal = React.createClass({
       var dataclass = {
           "name": this.state.name,
           "is_event": false,
+          "is_resource": false,
           "attributes": [],
           "olc": Config.DEFAULT_OLC_XML
       };

--- a/public_src/js/resourceApi.js
+++ b/public_src/js/resourceApi.js
@@ -1,0 +1,15 @@
+var Config = require('./../../config');
+
+var ResourceAPI = function(host) {
+    this.host = host;
+};
+
+ResourceAPI.prototype.createResourceURL = function(endpoint) {
+    return this.host.concat("resources/" + endpoint);
+};
+
+ResourceAPI.prototype.getAvailableResourceTypes = function(callback) {
+    $.getJSON(this.createResourceURL(""), callback);
+}
+
+module.exports = new ResourceAPI(Config.RESOURCE_MANAGER_HOST);

--- a/server_src/models/domainmodel.js
+++ b/server_src/models/domainmodel.js
@@ -17,6 +17,7 @@ var DomainModelSchema = new Schema({
         is_root: Boolean,
         is_event: Boolean,
         is_resource: Boolean,
+        resource_id: String,
         attributes: [{
             name: String,
             datatype: String

--- a/server_src/models/domainmodel.js
+++ b/server_src/models/domainmodel.js
@@ -16,6 +16,7 @@ var DomainModelSchema = new Schema({
         name: String,
         is_root: Boolean,
         is_event: Boolean,
+        is_resource: Boolean,
         attributes: [{
             name: String,
             datatype: String


### PR DESCRIPTION
This PR adds a checkbox for defining a data model as a resource.
If the box is checked, the user can select to which resource type he/she refers to.
The list of available types is fetched from the resource manager (currently a mock [served from here](https://github.com/MaximilianV/resource-mock)).

See #50.
