### PR TITLE
SVG download for fragments

### DIFF
--- a/public_src/js/bpmn/editor.js
+++ b/public_src/js/bpmn/editor.js
@@ -74,4 +74,22 @@ Editor.prototype.handleChange = function(event, object) {
     }
 };
 
+Editor.prototype.downloadSVG = function(filename) {
+    
+    this.renderer.saveSVG({}, function(err, svgStr) {
+
+        var element = document.createElement('a');
+        element.setAttribute('href', 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgStr));
+        element.setAttribute('download', filename);
+      
+        element.style.display = 'none';
+        document.body.appendChild(element);
+      
+        element.click();
+      
+        document.body.removeChild(element);
+
+    });
+}
+
 module.exports = Editor;

--- a/public_src/js/bpmn/editor.js
+++ b/public_src/js/bpmn/editor.js
@@ -75,6 +75,9 @@ Editor.prototype.handleChange = function(event, object) {
 };
 
 Editor.prototype.downloadSVG = function(filename) {
+
+    // Replace non-alphanumeric characters (except for '-' and '.') with '-'
+    filename = filename.replace(/[^a-zA-Z0-9\-.]+/g, '-');
     
     this.renderer.saveSVG({}, function(err, svgStr) {
 

--- a/public_src/js/react/fragmenteditor/fragmenteditor.js
+++ b/public_src/js/react/fragmenteditor/fragmenteditor.js
@@ -37,6 +37,13 @@ var FragmentEditorComponent = React.createClass({
           handleBoundChange={this.handleBoundChange}
         />
         <hr />
+          <button
+            type="button"
+            className="btn btn-success"
+            onClick={this.downloadSVG}>
+              <i className={"fa fa-download"} /> Download fragment as SVG
+          </button>
+        <hr />
         <div className="fragmentEditor">
           <div className="canvas" id="fragment-canvas" />
           <div className="properties-panel" id="fragment-properties" />
@@ -113,6 +120,9 @@ var FragmentEditorComponent = React.createClass({
         API.exportFragment(data, res_handler);
       });
     }
+  },
+  downloadSVG: function() {
+    this.state.editor.downloadSVG(this.state.fragment.name + ".svg");
   },
   handlePreConditionChange: function(preconditions) {
     var fragment = this.state.fragment;


### PR DESCRIPTION
This introduces a neat little download button for the fragment editor to download the rendered graphic as SVG. Like this:
![image](https://user-images.githubusercontent.com/5867277/56042160-b2289080-5d3a-11e9-8698-4fbf99e987d1.png)

Useful for extracting models for paper / thesis / presentation purposes.

@svenihde @MaximilianV interested?
