### PR TITLE
Add checkbox for automatic fragment execution

### DIFF
--- a/public_src/js/react/fragmenteditor/fragmenteditor.js
+++ b/public_src/js/react/fragmenteditor/fragmenteditor.js
@@ -121,7 +121,7 @@ var FragmentEditorComponent = React.createClass({
     this.setState({ fragment: fragment });
   },
   handleAutomaticActivationChange: function(automaticActivation) {
-    var fragment = this.state.fragment;
+    const fragment = this.state.fragment;
     fragment.automaticActivation = automaticActivation;
     this.setState({ fragment: fragment });
   },

--- a/public_src/js/react/fragmenteditor/fragmenteditor.js
+++ b/public_src/js/react/fragmenteditor/fragmenteditor.js
@@ -16,6 +16,7 @@ var FragmentEditorComponent = React.createClass({
         content: "",
         policy: "",
         bound: {},
+        automaticActivation: false,
         preconditions: [""],
         revision: 0
       },
@@ -35,6 +36,7 @@ var FragmentEditorComponent = React.createClass({
           fragment={this.state.fragment}
           changePolicy={this.handlePolicyChange}
           handleBoundChange={this.handleBoundChange}
+          changeAutomaticActivation={this.handleAutomaticActivationChange}
         />
         <hr />
         <div className="fragmentEditor">
@@ -116,6 +118,11 @@ var FragmentEditorComponent = React.createClass({
   handleBoundChange: function(bound) {
     var fragment = this.state.fragment;
     fragment.bound = bound;
+    this.setState({ fragment: fragment });
+  },
+  handleAutomaticActivationChange: function(automaticActivation) {
+    var fragment = this.state.fragment;
+    fragment.automaticActivation = automaticActivation;
     this.setState({ fragment: fragment });
   },
   componentWillUnmount: function() {

--- a/public_src/js/react/fragmenteditor/fragmentinstantiationpolicy.js
+++ b/public_src/js/react/fragmenteditor/fragmentinstantiationpolicy.js
@@ -131,6 +131,26 @@ var InstantiationPolicyComponent = React.createClass({
           </div>
           {limit}
         </div>
+        <br />
+        <div className="row">
+          <div className="col-sm-2 checkbox">
+            <label>
+              <input
+                  name="automaticExecution"
+                  type="checkbox"
+                  //checked={this.state.hasBound}
+              />
+              Is started automatically
+            </label>
+            &nbsp;
+            <a
+                data-toggle="tooltip"
+                title="If checked the fragment will be enabled whenever the dataflow is enabled"
+            >
+              <i className="fa fa-info-circle" />
+            </a>
+          </div>
+        </div>
       </form>
     );
   }

--- a/public_src/js/react/fragmenteditor/fragmentinstantiationpolicy.js
+++ b/public_src/js/react/fragmenteditor/fragmentinstantiationpolicy.js
@@ -6,7 +6,8 @@ var InstantiationPolicyComponent = React.createClass({
       policy: "",
       hasBound: "",
       limit: "",
-      _id: ""
+      _id: "",
+      automaticActivation: ""
     };
   },
   componentDidMount: function() {
@@ -16,7 +17,8 @@ var InstantiationPolicyComponent = React.createClass({
         ? this.props.fragment.bound.hasBound
         : false,
       limit: this.props.fragment.bound ? this.props.fragment.bound.limit : 10,
-      _id: this.props.fragment._id
+      _id: this.props.fragment._id,
+      automaticActivation: this.props.fragment.automaticActivation
     });
   },
   componentDidUpdate: function() {
@@ -27,7 +29,8 @@ var InstantiationPolicyComponent = React.createClass({
           ? this.props.fragment.bound.hasBound
           : false,
         limit: this.props.fragment.bound ? this.props.fragment.bound.limit : 10,
-        _id: this.props.fragment._id
+        _id: this.props.fragment._id,
+        automaticActivation: this.props.fragment.automaticActivation
       });
     }
   },
@@ -47,6 +50,11 @@ var InstantiationPolicyComponent = React.createClass({
       },
       this.submitBound
     );
+  },
+  handleAutomaticActivationChange: function(event) {
+    const value = event.target.checked;
+    this.setState({ automaticActivation: value });
+    this.props.changeAutomaticActivation(value);
   },
   submitBound() {
     const bound = {
@@ -136,16 +144,17 @@ var InstantiationPolicyComponent = React.createClass({
           <div className="col-sm-2 checkbox">
             <label>
               <input
-                  name="automaticExecution"
+                  name="automaticActivation"
                   type="checkbox"
-                  //checked={this.state.hasBound}
+                  checked={this.state.automaticActivation}
+                  onChange={this.handleAutomaticActivationChange}
               />
-              Is started automatically
+              Is activated automatically
             </label>
             &nbsp;
             <a
                 data-toggle="tooltip"
-                title="If checked the fragment will be enabled whenever the dataflow is enabled"
+                title="If checked the fragment will be activated whenever the dataflow is enabled"
             >
               <i className="fa fa-info-circle" />
             </a>

--- a/server_src/helpers/throweventvalidator.js
+++ b/server_src/helpers/throweventvalidator.js
@@ -50,7 +50,7 @@ var ThrowEventValidator = class {
 		    if (foundDc !== undefined &&
 			!foundDc.is_event) {
 			this.messages.push({
-			    'text': 'Data input of message send event is not a event class.',
+			    'text': 'Data input of message send event is not an event class.',
 			    'type': 'danger'
 			});
 		    }

--- a/server_src/models/fragment.js
+++ b/server_src/models/fragment.js
@@ -17,6 +17,7 @@ var FragmentSchema = new Schema({
 		hasBound: Boolean,
 		limit: Number
 	},
+    automaticActivation: Boolean,
     preconditions: [{type: String}],
     revision: Number
 });

--- a/server_src/routes/fragment.js
+++ b/server_src/routes/fragment.js
@@ -133,7 +133,7 @@ router.post('/', function(req, res) {
         preconditions: (fragment.preconditions ? fragment.preconditions : [""]),
         policy: (fragment.policy ? fragment.policy : Config.DEFAULT_FRAGMENT_POLICY),
         bound: (fragment.bound ? fragment.bound : {hasBound: false, limit: Config.DEFAULT_FRAGMENT_INSTANTIATION_AMOUNT}),
-        automaticActivation: (fragment.automaticActivation ? fragment.automaticActivation : false),
+        automaticActivation: !!fragment.automaticActivation,
         revision: 1
     });
 

--- a/server_src/routes/fragment.js
+++ b/server_src/routes/fragment.js
@@ -78,6 +78,11 @@ router.post('/:fragID', function(req, res) {
 				result.bound = new_frag.bound;
 			}
 
+			if (new_frag.automaticActivation != null && result.automaticActivation !== new_frag.automaticActivation) {
+			    changed = true;
+			    result.automaticActivation = new_frag.automaticActivation;
+            }
+
             if (changed) {
                 result.revision++;
                 result.save(function(err){
@@ -128,6 +133,7 @@ router.post('/', function(req, res) {
         preconditions: (fragment.preconditions ? fragment.preconditions : [""]),
         policy: (fragment.policy ? fragment.policy : Config.DEFAULT_FRAGMENT_POLICY),
         bound: (fragment.bound ? fragment.bound : {hasBound: false, limit: Config.DEFAULT_FRAGMENT_INSTANTIATION_AMOUNT}),
+        automaticActivation: (fragment.automaticActivation ? fragment.automaticActivation : false),
         revision: 1
     });
 

--- a/server_src/routes/scenario.js
+++ b/server_src/routes/scenario.js
@@ -108,6 +108,7 @@ router.post('/', function(req, res) {
                         hasBound: false,
                         limit: Config.DEFAULT_FRAGMENT_INSTANTIATION_AMOUNT
                     },
+                    new_fragment.automaticActivation = false;
                     new_fragment.revision = 1;
                     new_fragment.save();
                     scenario.fragments = [];
@@ -124,6 +125,7 @@ router.post('/', function(req, res) {
                             new_fragment.preconditions = fragment.preconditions;
                             new_fragment.policy = fragment.policy;
                             new_fragment.bound = fragment.bound;
+                            new_fragment.automaticActivation = fragment.automaticActivation;
                             new_fragment.save();
                             scenario.fragments = [];
                             db_scenario.fragments.push(new_fragment._id);


### PR DESCRIPTION
When having a process that is supposed to be executed automatically there may be fragments without a message receive start event that have to be executed automatically (i.e. the first fragment to be executed after a case start trigger).